### PR TITLE
Add test for checking value type

### DIFF
--- a/tests/functional/test_value_type.py
+++ b/tests/functional/test_value_type.py
@@ -1,0 +1,30 @@
+
+from __future__ import unicode_literals
+import pytest
+
+from textx.metamodel import metamodel_from_str
+from textx.export import metamodel_export, model_export
+
+
+def test_value_type():
+    """
+    Test object processors in context of match rules with base types.
+    """
+
+    grammar = """
+        Program:
+            'max_value' '=' max_value=INT
+        ;
+    """
+
+    mm = metamodel_from_str(grammar)
+    metamodel_export(mm, 'test_value_type.dot')
+
+    model_str = """
+            max_value = 5.5
+    """
+
+    # Test raises:
+    # TextXSyntaxError: Expected 'EOF' at position (2, 26) => '_value = 5*.5.
+    model = mm.model_from_str(model_str)
+    model_export(model, 'test_value_type.dot')


### PR DESCRIPTION
Test raises EOF exception when instead of INT value, you set FLOAT.
Exception should be raised, but the message should indicate that
parser expects INT instead some other value.